### PR TITLE
Persist scheduled events

### DIFF
--- a/db/events.go
+++ b/db/events.go
@@ -11,16 +11,19 @@ import (
 const scheduleDatabaseName = "ScheduledEvents"
 const scheduleBucketName = scheduleDatabaseName
 
-// What should the we do with the event after your operation completes?
+// What should we do with the event after your operation completes?
 type EventOperationResult int8
 
 const (
-	DoNothing   EventOperationResult = 0
+	// Don't do anything with the event afdter your operation completes.
+	DoNothing EventOperationResult = 0
+	// Update the event in the database after your operation completes (because you modified it).
 	UpdateEvent EventOperationResult = 1
+	// Delete the event in the database after your operation completes (because you no longer need it).
 	DeleteEvent EventOperationResult = 2
 )
 
-// You MUST NOT modify or read the database inside these operations, or we're at risk of deadlocking.
+// You MUST NOT read/modify the database inside these operations or we'll be at risk of deadlocking/undefined behavior.
 type ScheduledEventOperation = func(*models.ScheduledEvent) (EventOperationResult, error)
 
 func forEachScheduledEvent(db *bbolt.DB, op ScheduledEventOperation) error {

--- a/db/events.go
+++ b/db/events.go
@@ -1,0 +1,133 @@
+package db
+
+import (
+	"encoding/json"
+	"log"
+
+	"github.com/janimationd/JacuzziBot/models"
+	"go.etcd.io/bbolt"
+)
+
+const scheduleDatabaseName = "ScheduledEvents"
+const scheduleBucketName = scheduleDatabaseName
+
+// What should the we do with the event after your operation completes?
+type EventOperationResult int8
+
+const (
+	DoNothing   EventOperationResult = 0
+	UpdateEvent EventOperationResult = 1
+	DeleteEvent EventOperationResult = 2
+)
+
+// You MUST NOT modify or read the database inside these operations, or we're at risk of deadlocking.
+type ScheduledEventOperation = func(*models.ScheduledEvent) (EventOperationResult, error)
+
+func forEachScheduledEvent(db *bbolt.DB, op ScheduledEventOperation) error {
+	return db.Update(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket([]byte(scheduleBucketName))
+		if bucket == nil {
+			return nil
+		}
+
+		bucket.ForEach(func(k, v []byte) error {
+			event := &models.ScheduledEvent{}
+			err := json.Unmarshal(v, event)
+			if err != nil {
+				// Don't fail the whole loop, just log and skip over the broken one.
+				log.Printf("Couldn't unmarshall event %s: %s\n", k, err.Error())
+				return nil
+			}
+
+			// Execute the caller-provided operation on the event
+			opResult, err := op(event)
+			if err != nil {
+				return err
+			}
+			switch opResult {
+			case UpdateEvent:
+				eventBytes, err := json.Marshal(event)
+				if err != nil {
+					// Don't fail the whole loop, just log and skip over the broken one.
+					log.Printf("Couldn't marshall event %s: %s\n", k, err.Error())
+					return nil
+				}
+				err = bucket.Put(k, eventBytes)
+				if err != nil {
+					// Don't fail the whole loop, just log and skip over the broken one.
+					log.Printf("Couldn't update original event %s: %s\n", k, err.Error())
+					return nil
+				}
+			case DeleteEvent:
+				err := bucket.Delete(k)
+				if err != nil {
+					// Don't fail the whole loop, just log and skip over the broken one.
+					log.Printf("Couldn't delete event %s: %s\n", k, err.Error())
+					return nil
+				}
+			}
+			return nil
+		})
+		return nil
+	})
+}
+
+func scheduleEvent(db *bbolt.DB, event *models.ScheduledEvent, overwriteIfPresent bool) (bool, error) {
+	modified := false
+
+	err := db.Update(func(tx *bbolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists([]byte(scheduleBucketName))
+		if err != nil {
+			return err
+		}
+
+		if !overwriteIfPresent {
+			existingEventBytes := bucket.Get([]byte(event.ID))
+			if existingEventBytes != nil {
+				return nil
+			}
+		}
+
+		eventBytes, err := json.Marshal(event)
+		if err != nil {
+			return err
+		}
+		err = bucket.Put([]byte(event.ID), eventBytes)
+		if err != nil {
+			modified = true
+		}
+
+		return err
+	})
+
+	if err != nil {
+		log.Printf("Couldn't schedule event %s: %s\n", event.ID, err.Error())
+	}
+
+	return modified, err
+}
+
+// Perform an operation on each event in the schedule. Your op returns what we should do with the event after
+// the function completes. If op returns an error, the entire loop exits early and the error is returned.
+func ForEachScheduledEvent(op ScheduledEventOperation) error {
+	// Create or open a server-specific database file
+	db, err := getDb(scheduleDatabaseName)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	return forEachScheduledEvent(db, op)
+}
+
+// Adds a new event ot the schedule. Returns whether the event was added into the schedule in or not.
+func ScheduleEvent(event *models.ScheduledEvent, overwriteIfPresent bool) (bool, error) {
+	// Create or open a server-specific database file
+	db, err := getDb(scheduleDatabaseName)
+	if err != nil {
+		return false, err
+	}
+	defer db.Close()
+
+	return scheduleEvent(db, event, overwriteIfPresent)
+}

--- a/db/events.go
+++ b/db/events.go
@@ -123,7 +123,7 @@ func ForEachScheduledEvent(op ScheduledEventOperation) error {
 	return forEachScheduledEvent(db, op)
 }
 
-// Adds a new event ot the schedule. Returns whether the event was added into the schedule in or not.
+// Adds a new event to the schedule. Returns whether the event was added into the schedule in or not.
 func ScheduleEvent(event *models.ScheduledEvent, overwriteIfPresent bool) (bool, error) {
 	// Create or open a server-specific database file
 	db, err := getDb(scheduleDatabaseName)

--- a/models/scheduledEvent.go
+++ b/models/scheduledEvent.go
@@ -1,21 +1,29 @@
 package models
 
 import (
+	"encoding/json"
 	"log"
 	"time"
 )
 
-// A recurring event in the schedule
+// An event in the schedule.
 type ScheduledEvent struct {
-	// The Name of the event (should be unique, but not enforced)
-	Name string
+	// A server-unique ID for this event. This should also be descriptive, e.g. also function as an event name.
+	ID string
 	// The next scheduled time to trigger the event at. If zero, it means the event will not happen again.
 	NextTime time.Time
 	// How long between scheduled event triggers. If zero, it means nextTime will not be advanced after the next event.
 	Interval time.Duration
-	// The Callback function to call when the event triggers. Passes in the event name.
-	Callback func(string)
+	// The handler name for the event.
+	Handler string
+	// A data payload to be stored with the event, containing the parameters to the Handler.
+	Payload json.RawMessage
 }
+
+// A function to handle an event when it is time for the event to "happen". You are allowed to edit the event as you
+// see fit. You DO NOT need to do any timing logic in your function unless you're doing something non-standard.
+// NextTime is advanced by Interval for you after your handler is called.
+type EventHandler func(event *ScheduledEvent)
 
 // Set nextTime to be the next wall clock-aligned interval boundary.
 func (event *ScheduledEvent) Init() {
@@ -31,7 +39,7 @@ func (event *ScheduledEvent) Init() {
 		result = result.Add(event.Interval)
 	}
 	event.NextTime = result
-	log.Printf("ScheduledEvent \"%s\" initialized with nextTime = %s\n", event.Name, event.NextTime.String())
+	log.Printf("ScheduledEvent \"%s\" initialized with nextTime = %s\n", event.ID, event.NextTime.String())
 }
 
 // Returns true if the event is not going to happen again, false otherwise.
@@ -45,21 +53,25 @@ func (event *ScheduledEvent) updateNextTime() {
 		return
 	}
 	if event.Interval == 0 {
-		log.Printf("ScheduledEvent \"%s\" will not execute again.\n", event.Name)
+		log.Printf("ScheduledEvent \"%s\" will not execute again.\n", event.ID)
 		// Reset nextTime to 0.
 		event.NextTime = time.Time{}
 		return
 	}
 	event.NextTime = event.NextTime.Add(event.Interval)
-	log.Printf("ScheduledEvent \"%s\" advanced to nextTime = %s\n", event.Name, event.NextTime.String())
+	log.Printf("ScheduledEvent \"%s\" advanced to nextTime = %s\n", event.ID, event.NextTime.String())
 }
 
-func (event *ScheduledEvent) Check() {
+// Check if it's time for the event to happen, and then handle it and advance NextTime if yes. Returns whether or not
+// the event happened.
+func (event *ScheduledEvent) CheckAndHandle(handler EventHandler) bool {
 	now := time.Now()
 
 	// If it's time to execute the event
 	if now.Equal(event.NextTime) || now.After(event.NextTime) {
-		event.Callback(event.Name)
+		handler(event)
 		event.updateNextTime()
+		return true
 	}
+	return false
 }

--- a/models/scheduledEvent.go
+++ b/models/scheduledEvent.go
@@ -14,6 +14,12 @@ type ScheduledEvent struct {
 	NextTime time.Time
 	// How long between scheduled event triggers. If zero, it means nextTime will not be advanced after the next event.
 	Interval time.Duration
+	// If this is a recurring event, this defines how long the bot has to be shut down for before we give up on trying
+	// to catch back up to where we were. For example: if Interval is X, this is Y, and the bot is shut down for longer
+	// than Y, then we don't race through all the Intervals we missed. Instead we just skip NextTime ahead to the next
+	// Interval boundary. In practice we don't expect long bot outages for the actual bot, but this happens often with
+	// our personal bot instances used for testing and local development.
+	RestartGapTolerance time.Duration
 	// The handler name for the event.
 	Handler string
 	// A data payload to be stored with the event, containing the parameters to the Handler.
@@ -21,9 +27,10 @@ type ScheduledEvent struct {
 }
 
 // A function to handle an event when it is time for the event to "happen". You are allowed to edit the event as you
-// see fit. You DO NOT need to do any timing logic in your function unless you're doing something non-standard.
-// NextTime is advanced by Interval for you after your handler is called.
-type EventHandler func(event *ScheduledEvent)
+// see fit, but your handler MUST return true if you edit it so we know to update the event in the database. You DO
+// NOT need to do any timing logic in your function unless you're doing something non-standard. NextTime is advanced
+// by Interval for you after your handler is called.
+type EventHandler func(event *ScheduledEvent) bool
 
 // Set nextTime to be the next wall clock-aligned interval boundary.
 func (event *ScheduledEvent) Init() {
@@ -39,7 +46,7 @@ func (event *ScheduledEvent) Init() {
 		result = result.Add(event.Interval)
 	}
 	event.NextTime = result
-	log.Printf("ScheduledEvent \"%s\" initialized with nextTime = %s\n", event.ID, event.NextTime.String())
+	log.Printf("ScheduledEvent \"%s\" initialized with NextTime = [%s]\n", event.ID, event.NextTime.String())
 }
 
 // Returns true if the event is not going to happen again, false otherwise.
@@ -47,31 +54,51 @@ func (event *ScheduledEvent) IsDone() bool {
 	return event.NextTime.IsZero()
 }
 
-// Advances the nextTime of the event to the next scheduled time after its current value.
-func (event *ScheduledEvent) updateNextTime() {
+// Advances the nextTime of the event to the next scheduled time after its current value. Returns whether the event
+// was modified.
+func (event *ScheduledEvent) updateNextTime() bool {
 	if event.NextTime.IsZero() {
-		return
+		log.Printf("ScheduledEvent \"%s\" has no NextTime to advance past.\n", event.ID)
+		return false
 	}
 	if event.Interval == 0 {
 		log.Printf("ScheduledEvent \"%s\" will not execute again.\n", event.ID)
 		// Reset nextTime to 0.
 		event.NextTime = time.Time{}
-		return
+		return true
 	}
 	event.NextTime = event.NextTime.Add(event.Interval)
-	log.Printf("ScheduledEvent \"%s\" advanced to nextTime = %s\n", event.ID, event.NextTime.String())
+	log.Printf("ScheduledEvent \"%s\" advanced to NextTime = %s\n", event.ID, event.NextTime.String())
+	return true
 }
 
 // Check if it's time for the event to happen, and then handle it and advance NextTime if yes. Returns whether or not
-// the event happened.
+// the event was modified.
 func (event *ScheduledEvent) CheckAndHandle(handler EventHandler) bool {
-	now := time.Now()
+	// If NextTime is more than RestartGapTolerance in the past, then the bot has been shut down for a while and we
+	// shouldn't iterate through every Interval since it last ran to catch back up. Instead skip ahead to what NextTime
+	// should next be.
+	shouldCheckRestartGapTolerance := event.Interval != 0 && event.RestartGapTolerance != 0
+	// log.Printf("> Interval = %s, RestartGapTolerance = %s, NextTime = [%s], TimeUntil = %s\n",
+	// 	event.Interval.String(), event.RestartGapTolerance.String(), event.NextTime, time.Until(event.NextTime).String())
+	if shouldCheckRestartGapTolerance && time.Until(event.NextTime) <= -event.RestartGapTolerance {
+		originalNextTime := event.NextTime
+		event.NextTime = time.Time{}
+		// Reinitialize the event to properly calculate NextTime from the Interval.
+		event.Init()
+		log.Printf("Event %s's NextTime was [%s], which is too far in the past. "+
+			"Advancing NextTime to [%s] and skipping the Intervals we missed.\n",
+			event.ID, originalNextTime, event.NextTime)
+		return true
+	}
 
+	now := time.Now()
 	// If it's time to execute the event
 	if now.Equal(event.NextTime) || now.After(event.NextTime) {
-		handler(event)
-		event.updateNextTime()
-		return true
+		modified := handler(event)
+		// Order of operands is important: always execute updateNextTime().
+		modified = event.updateNextTime() || modified
+		return modified
 	}
 	return false
 }

--- a/models/scheduledEvent.go
+++ b/models/scheduledEvent.go
@@ -8,11 +8,13 @@ import (
 
 // An event in the schedule.
 type ScheduledEvent struct {
-	// A server-unique ID for this event. This should also be descriptive, e.g. also function as an event name.
+	// A server-unique ID for this event. This should also be descriptive, e.g. also function as an event name. If
+	// you're generating many instances of an event from one part of code, you'll need to make sure this is unique
+	// somehow, for example, by appending a millisecond (or better) timestamp.
 	ID string
 	// The next scheduled time to trigger the event at. If zero, it means the event will not happen again.
 	NextTime time.Time
-	// How long between scheduled event triggers. If zero, it means nextTime will not be advanced after the next event.
+	// How long between scheduled event triggers. If zero, it means NextTime will not be advanced after the next event.
 	Interval time.Duration
 	// If this is a recurring event, this defines how long the bot has to be shut down for before we give up on trying
 	// to catch back up to where we were. For example: if Interval is X, this is Y, and the bot is shut down for longer
@@ -32,7 +34,7 @@ type ScheduledEvent struct {
 // by Interval for you after your handler is called.
 type EventHandler func(event *ScheduledEvent) bool
 
-// Set nextTime to be the next wall clock-aligned interval boundary.
+// Set NextTime to be the next wall clock-aligned Interval boundary.
 func (event *ScheduledEvent) Init() {
 	// Pre-scheduled events don't need to be initialized.
 	if !event.NextTime.IsZero() {
@@ -41,7 +43,7 @@ func (event *ScheduledEvent) Init() {
 
 	now := time.Now()
 	result := now.Round(event.Interval)
-	// If it rounded down, add one interval to get our next time.
+	// If it rounded down, add one Interval to get our next time.
 	if result.Before(now) {
 		result = result.Add(event.Interval)
 	}
@@ -54,7 +56,7 @@ func (event *ScheduledEvent) IsDone() bool {
 	return event.NextTime.IsZero()
 }
 
-// Advances the nextTime of the event to the next scheduled time after its current value. Returns whether the event
+// Advances the NextTime of the event to the next scheduled time after its current value. Returns whether the event
 // was modified.
 func (event *ScheduledEvent) updateNextTime() bool {
 	if event.NextTime.IsZero() {
@@ -63,7 +65,7 @@ func (event *ScheduledEvent) updateNextTime() bool {
 	}
 	if event.Interval == 0 {
 		log.Printf("ScheduledEvent \"%s\" will not execute again.\n", event.ID)
-		// Reset nextTime to 0.
+		// Reset NextTime to 0.
 		event.NextTime = time.Time{}
 		return true
 	}

--- a/scheduler/events/voiceCallPointAwarder.go
+++ b/scheduler/events/voiceCallPointAwarder.go
@@ -12,33 +12,36 @@ import (
 
 // When X people are in a voice call, award them each Y points every minute.
 var VoiceCallPointAwarder = models.ScheduledEvent{
-	Name:     "VoiceCallPointAwarder",
+	ID:       "VoiceCallPointAwarder",
 	Interval: 1 * time.Minute,
-	Callback: func(eventName string) {
-		if discord.Session == nil {
-			log.Println("Discord session is nil, not checking voice calls.")
-			return
+	Handler:  "VoiceCallPointAwarderHandler",
+}
+
+func VoiceCallPointAwarderHandler(event *models.ScheduledEvent) {
+	if discord.Session == nil {
+		log.Println("Discord session is nil, not checking voice calls.")
+		return
+	}
+
+	// Iterate over all of the servers/guilds we're currently connected to.
+	for _, guild := range discord.Session.State.Guilds {
+		voiceCalls, err := db.GetAllVoiceCallsWithParticipants(guild.ID)
+		if err != nil {
+			log.Printf("Unable to fetch voice calls for server %s (%s): %s\n", guild.ID, guild.Name, err.Error())
+			continue
 		}
-		// Iterate over all of the servers/guilds we're currently connected to.
-		for _, guild := range discord.Session.State.Guilds {
-			voiceCalls, err := db.GetAllVoiceCallsWithParticipants(guild.ID)
-			if err != nil {
-				log.Printf("Unable to fetch voice calls for server %s (%s): %s\n", guild.ID, guild.Name, err.Error())
-				continue
+		// Iterate over all of the voice calls in that server
+		for _, voiceCall := range voiceCalls {
+			participantCount := voiceCall.Users.Size()
+			pointAwardValue := float64(participantCount) * constants.VoiceCallPointsPerParticipantPerMinute
+			if participantCount > 0 {
+				log.Printf("Awarding %.2f points to all %d users in voice channel %s.\n",
+					pointAwardValue, participantCount, voiceCall.ChannelId)
 			}
-			// Iterate over all of the voice calls in that server
-			for _, voiceCall := range voiceCalls {
-				participantCount := voiceCall.Users.Size()
-				pointAwardValue := float64(participantCount) * constants.VoiceCallPointsPerParticipantPerMinute
-				if participantCount > 0 {
-					log.Printf("Awarding %.2f points to all %d users in voice channel %s.\n",
-						pointAwardValue, participantCount, voiceCall.ChannelId)
-				}
-				// Iterate over all of the users in the voice call
-				for userId := range voiceCall.Users.All() {
-					db.ModifyUserPoints(guild.ID, userId, pointAwardValue)
-				}
+			// Iterate over all of the users in the voice call
+			for userId := range voiceCall.Users.All() {
+				db.ModifyUserPoints(guild.ID, userId, pointAwardValue)
 			}
 		}
-	},
+	}
 }

--- a/scheduler/events/voiceCallPointAwarder.go
+++ b/scheduler/events/voiceCallPointAwarder.go
@@ -12,15 +12,16 @@ import (
 
 // When X people are in a voice call, award them each Y points every minute.
 var VoiceCallPointAwarder = models.ScheduledEvent{
-	ID:       "VoiceCallPointAwarder",
-	Interval: 1 * time.Minute,
-	Handler:  "VoiceCallPointAwarderHandler",
+	ID:                  "VoiceCallPointAwarder",
+	Interval:            1 * time.Minute,
+	Handler:             "VoiceCallPointAwarderHandler",
+	RestartGapTolerance: 5 * time.Minute,
 }
 
-func VoiceCallPointAwarderHandler(event *models.ScheduledEvent) {
+func VoiceCallPointAwarderHandler(event *models.ScheduledEvent) bool {
 	if discord.Session == nil {
 		log.Println("Discord session is nil, not checking voice calls.")
-		return
+		return false
 	}
 
 	// Iterate over all of the servers/guilds we're currently connected to.
@@ -44,4 +45,5 @@ func VoiceCallPointAwarderHandler(event *models.ScheduledEvent) {
 			}
 		}
 	}
+	return false
 }

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -5,41 +5,57 @@ import (
 	"log"
 	"time"
 
+	"github.com/janimationd/JacuzziBot/db"
 	"github.com/janimationd/JacuzziBot/models"
 	"github.com/janimationd/JacuzziBot/scheduler/events"
 )
 
-var schedule []*models.ScheduledEvent
+// The registered event handlers.
+var eventRegistry = map[string]models.EventHandler{}
 
-// Puts all known events on the schedule.
-func setup() {
+// This ensures both that the event is in the database already (indexed by event.ID) and that the handler is
+// registered (indexed by event.Handler). Caller chooses whether to overwrite if values for those keys already exist.
+func RegisterEventAndHandler(
+	event *models.ScheduledEvent,
+	handler models.EventHandler,
+	overwriteIfPresent bool,
+) error {
+	event.Init()
+	// Add to the database.
+	_, err := db.ScheduleEvent(event, overwriteIfPresent)
+	if err != nil {
+		return err
+	}
+	if overwriteIfPresent || eventRegistry[event.Handler] == nil {
+		eventRegistry[event.Handler] = handler
+	}
+	return nil
+}
+
+// Puts all crucial events on the schedule at startup. "Crucial" here just means "we know we need it at startup".
+func setupCrucialEvents() {
 	// Create and append all scheduled events here. Examples (though they should each be defined in their own files):
 	//
 	// schedule = append(schedule, &ScheduledEvent{
 	// 	   name:     "ExampleRecurringEvent",
 	//     interval: 1 * time.Minute,
-	// 	   callback: func(eventName string) { log.Println(eventName + ": " + time.Now().String()) },
+	//     ...
 	// })
 	//
 	// schedule = append(schedule, &ScheduledEvent{
 	// 	   name:     "ExampleOneOffEvent",
 	// 	   nextTime: time.Now().Add(30 * time.Second),
-	// 	   callback: func(eventName string) { log.Println(eventName + ": " + time.Now().String()) },
+	//     ...
 	// })
 
-	schedule = append(schedule, &events.VoiceCallPointAwarder)
-
-	// Initialize all the events and set their next times.
-	for _, event := range schedule {
-		event.Init()
-	}
+	RegisterEventAndHandler(&events.VoiceCallPointAwarder, events.VoiceCallPointAwarderHandler, false)
 }
 
 const checkinterval = 1 * time.Second
 
 // Setup and run the schedule.
 func Run(ctx context.Context) {
-	setup()
+	setupCrucialEvents()
 
 	for {
 		loopStartTime := time.Now()
@@ -48,11 +64,26 @@ func Run(ctx context.Context) {
 			log.Println("Done signal received; shutting down scheduler.")
 			return
 		default:
-			for _, event := range schedule {
-				if !event.IsDone() {
-					event.Check()
+			// Execute logic directly inside the database transactions to ensure thread safety.
+			db.ForEachScheduledEvent(func(event *models.ScheduledEvent) (db.EventOperationResult, error) {
+				handler := eventRegistry[event.Handler]
+				if handler == nil {
+					log.Printf("Event %s had non existent handler %s\n", event.ID, event.Handler)
+					return db.DoNothing, nil
 				}
-			}
+
+				// Run the handler if it's time.
+				modified := event.CheckAndHandle(handler)
+
+				if event.IsDone() {
+					log.Printf("Event %s is done; deleting it\n", event.ID)
+					return db.DeleteEvent, nil
+				} else if modified {
+					log.Printf("Event %s was modified; updating it\n", event.ID)
+					return db.UpdateEvent, nil
+				}
+				return db.DoNothing, nil
+			})
 		}
 		// This won't be perfectly accurate, but that's fine.
 		loopEndTime := time.Now()

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -37,21 +37,22 @@ func setupCrucialEvents() {
 	// Create and append all scheduled events here. Examples (though they should each be defined in their own files):
 	//
 	// schedule = append(schedule, &ScheduledEvent{
-	// 	   name:     "ExampleRecurringEvent",
-	//     interval: 1 * time.Minute,
+	// 	   ID:                  "RecurringEvent",
+	//     Interval:            1 * time.Minute,
+	//     RestartGapTolerance: 5 * time.Minute,
 	//     ...
 	// })
 	//
 	// schedule = append(schedule, &ScheduledEvent{
-	// 	   name:     "ExampleOneOffEvent",
-	// 	   nextTime: time.Now().Add(30 * time.Second),
+	// 	   ID:       "OneOffEvent",
+	// 	   NextTime: time.Now().Add(30 * time.Second),
 	//     ...
 	// })
 
 	RegisterEventAndHandler(&events.VoiceCallPointAwarder, events.VoiceCallPointAwarderHandler, false)
 }
 
-const checkinterval = 1 * time.Second
+const checkInterval = 1 * time.Second
 
 // Setup and run the schedule.
 func Run(ctx context.Context) {
@@ -88,7 +89,7 @@ func Run(ctx context.Context) {
 		// This won't be perfectly accurate, but that's fine.
 		loopEndTime := time.Now()
 		loopDuration := loopEndTime.Sub(loopStartTime)
-		sleepDuration := max(checkinterval-loopDuration, 0)
+		sleepDuration := max(checkInterval-loopDuration, 0)
 		time.Sleep(sleepDuration)
 	}
 }


### PR DESCRIPTION
Fixes #18. ScheduledEvents now persist to their own non-server-specific database file called `ScheduledEvents.db`. That database is treated as the [SSOT](https://en.wikipedia.org/wiki/Single_source_of_truth) for our event schedule, and all operations on events should generally be done as part of a database transaction, and usually inside a `ForEachScheduledEvent()` call. To make this possible and sane, I also add a `RestartGapTolerance` field to each event which defines how long between bot restarts is considered too long to try "catching up" to where recurring events should be. If not used, or if the restart time gap is less than what we've configured, then once per second we'll advance the NextTime and call the event handler until we're caught back up to real-time.